### PR TITLE
Edit to pubdate

### DIFF
--- a/in_text/text_data_release.yml
+++ b/in_text/text_data_release.yml
@@ -24,7 +24,7 @@ abstract: >-
   This research was funded by the Midwest Climate Adaptation Science Center (MW CASC).
       
 authors: ["Julie A Padilla", "Jordan S Read", "Lindsay Platt", "Hayley Corson-Dosch", "Wallace (Andy) Mcaliley"]
-pubdate: 2022-12-15
+pubdate: 20221215
 doi: https://doi.org/10.5066/P9FY8JQC # replace with actual DOI
 
 build-environment: Multiple computer systems were used to generate these data, including linux, OSX. The open source language R was used on all systems.


### PR DESCRIPTION
I ran the metadata parser on your latest xml and got an error related to the pubdate. 

I believe for the xml, the pubdate should we written without the `-` separator, just as it is done for the [purpose start and end dates](https://github.com/padilla410/lake-temp-mo-data-release/blob/14e5fa486d9b26a4ab1403516ce2d504f5441515/in_text/text_data_release.yml#L403-L405). 

I suggest accepting this change, then uploading the new xml of the latest scipiper build (or from SB if it is already up) and running the file through the [metadata parser ](https://www1.usgs.gov/mp/) to see whether you get this or other errors. 